### PR TITLE
chore: add glama.json + server.json for registry discoverability

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["DanMat"]
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.danmat/packkit-mcp",
+  "title": "Packkit",
+  "description": "MCP server for Packkit — let AI agents scaffold modern npm packages, CLIs, services, and apps as a native tool.",
+  "version": "0.1.1",
+  "repository": {
+    "url": "https://github.com/DanMat/create-packkit",
+    "source": "github",
+    "subfolder": "mcp"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "packkit-mcp",
+      "version": "0.1.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The MCP server lives in the **mcp/** subfolder while the repo root is the `create-packkit` CLI, so registries that crawl the repo root (Glama, etc.) can't auto-detect/build it — which is why the Glama submission never indexed even though mcpservers.org approved it.

This adds the two standard metadata files at the repo root:

- **`glama.json`** — `maintainers: ["DanMat"]` so the server can be **claimed** on Glama. After merge + claim, the build is configured in Glama's admin panel (the existing `mcp/Dockerfile` is the build source).
- **`server.json`** — the official MCP-registry manifest with `repository.subfolder: "mcp"` and the published npm package (`packkit-mcp` → `npx packkit-mcp`, stdio), making the subfolder server discoverable across the ecosystem.



🤖 Generated with [Claude Code](https://claude.com/claude-code)