### PR TITLE
chore(mcp): prep packkit-mcp 0.1.2 for the official MCP registry

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "packkit-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
+  "mcpName": "io.github.danmat/packkit-mcp",
   "description": "MCP server for Packkit — let AI agents scaffold modern npm packages, CLIs, services, and apps as a native tool.",
   "type": "module",
   "bin": {

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -78,7 +78,7 @@ function fileTree(files) {
   return Object.keys(files).sort().map((p) => `  ${p}`).join('\n');
 }
 
-const server = new Server({ name: 'packkit', version: '0.1.1' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'packkit', version: '0.1.2' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.danmat/packkit-mcp",
   "title": "Packkit",
   "description": "MCP server for Packkit — let AI agents scaffold modern npm packages, CLIs, services, and apps as a native tool.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "url": "https://github.com/DanMat/create-packkit",
     "source": "github",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "packkit-mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Prepares `packkit-mcp` for publishing to the **official MCP registry** (registry.modelcontextprotocol.io), which makes it auto-installable across Glama, Cursor, VS Code, etc.

The registry verifies you own the npm package via an **`mcpName`** field in `package.json` that must match the `server.json` `name`. Since `0.1.1` is already on npm without it (and can't be republished), this bumps to **0.1.2**:

- `mcp/package.json` — add `"mcpName": "io.github.danmat/packkit-mcp"`, bump `0.1.2`
- `server.json` — `version` + package `version` → `0.1.2`
- `mcp/server.js` — reported server version → `0.1.2`

### To publish (after merge)
```bash
cd mcp
npm publish                 # publishes packkit-mcp@0.1.2 (needs npm auth)
cd ..
mcp-publisher login github  # opens browser, auth as DanMat
mcp-publisher publish       # reads server.json, verifies mcpName, publishes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)