### PR TITLE
fix: get packkit-mcp publishing to the official MCP registry (0.1.3)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "packkit-mcp",
-  "version": "0.1.2",
-  "mcpName": "io.github.danmat/packkit-mcp",
+  "version": "0.1.3",
+  "mcpName": "io.github.DanMat/packkit-mcp",
   "description": "MCP server for Packkit — let AI agents scaffold modern npm packages, CLIs, services, and apps as a native tool.",
   "type": "module",
   "bin": {

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -78,7 +78,7 @@ function fileTree(files) {
   return Object.keys(files).sort().map((p) => `  ${p}`).join('\n');
 }
 
-const server = new Server({ name: 'packkit', version: '0.1.2' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'packkit', version: '0.1.3' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.danmat/packkit-mcp",
   "title": "Packkit",
-  "description": "MCP server for Packkit — let AI agents scaffold modern npm packages, CLIs, services, and apps as a native tool.",
+  "description": "Scaffold modern npm packages, CLIs, services and apps as a native tool for AI agents.",
   "version": "0.1.2",
   "repository": {
     "url": "https://github.com/DanMat/create-packkit",

--- a/server.json
+++ b/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-  "name": "io.github.danmat/packkit-mcp",
+  "name": "io.github.DanMat/packkit-mcp",
   "title": "Packkit",
   "description": "Scaffold modern npm packages, CLIs, services and apps as a native tool for AI agents.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "url": "https://github.com/DanMat/create-packkit",
     "source": "github",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "packkit-mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Fixes to make `mcp-publisher publish` succeed:
- **description** trimmed to ≤ 100 chars (registry 422)
- **namespace casing**: `io.github.DanMat/packkit-mcp` (registry namespace is case-sensitive → `io.github.DanMat/*`); aligned `server.json` name + package `mcpName`
- **bump to 0.1.3**: npm 0.1.2 already shipped the lowercase `mcpName` and can't be overwritten, so a fresh publish is needed to carry the correct one

### Publish (after this is on your working tree — it already is)
```bash
cd mcp && npm publish && cd ..
mcp-publisher publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)