### PR TITLE
chore(mcp): sync package-lock self-version to 0.1.3

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "packkit-mcp",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "packkit-mcp",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Cosmetic: the lockfile's own version lagged at 0.1.1. `npm ci` already passed (deps in sync), so the Glama Docker build was fine — this just keeps the lockfile consistent with package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)