### PR TITLE
Fix service-framework selection and the growing command panel

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -18,12 +18,22 @@ function renderForm() {
   const form = $('#form');
   form.innerHTML = '';
   for (const group of GROUPS) {
-    const keys = Object.keys(OPTIONS).filter((k) => OPTIONS[k].group === group.id && !HIDDEN.has(k));
+    const keys = Object.keys(OPTIONS).filter(
+      (k) => OPTIONS[k].group === group.id && !HIDDEN.has(k) && applies(k, state),
+    );
     if (!keys.length) continue;
     const wrap = el('div', { className: 'group' }, el('h3', { textContent: group.label }));
     for (const key of keys) wrap.append(renderField(key));
     form.append(wrap);
   }
+}
+
+// An option that doesn't apply to the current config (a service framework with
+// no service target, a monorepo layout with no monorepo) is hidden rather than
+// shown-and-ignored: changing it would alter neither the command nor the files.
+function applies(key, cfg) {
+  const when = OPTIONS[key].when;
+  return typeof when === 'function' ? !!when(cfg) : true;
 }
 
 function renderField(key) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,10 @@
   .links a:hover { border-color: var(--accent); }
 
   main { display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: calc(100vh - 61px); }
+  /* Grid items default to min-width:auto, so a long unwrapped command sets the
+     column's minimum width and the whole panel grows with it. min-width:0 lets
+     the columns hold their share and the overflow-x below actually scroll. */
+  main > *, .split > * { min-width: 0; }
   @media (max-width: 900px) { main { grid-template-columns: 1fr; } }
 
   .config { padding: 22px 24px; overflow-y: auto; }

--- a/docs/packkit-core.js
+++ b/docs/packkit-core.js
@@ -47,6 +47,7 @@ var OPTIONS = {
     type: "select",
     label: "Service framework (HTTP service)",
     default: "hono",
+    when: (cfg) => cfg.target?.includes("service"),
     choices: [
       { value: "hono", label: "Hono (fast, web-standard)" },
       { value: "fastify", label: "Fastify" },

--- a/src/core/options.js
+++ b/src/core/options.js
@@ -36,6 +36,7 @@ export const OPTIONS = {
   },
   serviceFramework: {
     group: 'core', type: 'select', label: 'Service framework (HTTP service)', default: 'hono',
+    when: (cfg) => cfg.target?.includes('service'),
     choices: [
       { value: 'hono', label: 'Hono (fast, web-standard)' },
       { value: 'fastify', label: 'Fastify' },

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { generate, fromPreset, normalizeConfig, PRESETS, PRESET_INFO } from '../src/core/index.js';
+import { generate, fromPreset, normalizeConfig, PRESETS, PRESET_INFO, OPTIONS } from '../src/core/index.js';
 
 test('node-service: Hono app, Dockerfile, private, start script', () => {
   const out = generate(fromPreset('node-service', { name: 'svc' }));
@@ -370,4 +370,16 @@ test('packkit.json is deterministic — same config, same bytes', () => {
     generate(fromPreset('ts-lib', cfg)).files['packkit.json'],
     generate(fromPreset('ts-lib', cfg)).files['packkit.json'],
   );
+});
+
+test('options that do not apply declare it, so surfaces can hide them', () => {
+  // The web configurator showed these regardless, so changing them altered
+  // neither the command nor the generated files — which reads as a broken app.
+  assert.equal(typeof OPTIONS.serviceFramework.when, 'function');
+  assert.equal(OPTIONS.serviceFramework.when({ target: ['library'] }), false);
+  assert.equal(OPTIONS.serviceFramework.when({ target: ['library', 'service'] }), true);
+
+  assert.equal(typeof OPTIONS.monorepoLayout.when, 'function');
+  assert.equal(OPTIONS.monorepoLayout.when({ monorepo: false }), false);
+  assert.equal(OPTIONS.monorepoLayout.when({ monorepo: true }), true);
 });


### PR DESCRIPTION
Both bugs from using the configurator.

## Picking a service framework did nothing

Selecting **Express** left the command as `npx create-packkit my-package -y`.

The command builder only emits `--server` when the service target is selected, and that's *correct* — the flag is inert without it. The bug is that the control was rendered unconditionally, so clicking Express changed neither the command nor the files, which reads as a broken app.

Options can already declare when they apply, via a `when` predicate. **Nothing honored it.** The web configurator now does, so a control that can't affect the output isn't offered at all.

That also fixes a second instance I'd introduced: `Monorepo layout` shipped in 2.9.0 with a `when` that was quietly dead code, so it rendered even with monorepo off. The CLI wizard already guarded both cases by hand, so it was correct throughout — the web surface was the inconsistent one.

## The command box grew the page

Grid items default to `min-width: auto`, so an unwrapped 300-character command sets the column's minimum width. `.cmd` already had `overflow-x: auto`; it never got the chance to scroll.

Measured in the live page, toggling the fix off and on:

| | columns | page scroll width |
|---|---|---|
| without `min-width: 0` | **48px / 1534px** | 1582px (overflows) |
| with it | **720px / 720px** | 1440px (no overflow) |

That 48/1534 split is exactly the squeeze in the report — the form crushed, the preview enormous.

## Verified in the browser

- Default state: neither Service framework nor Monorepo layout is shown.
- Select **HTTP service** → the framework picker appears → **Express** yields `--server express --target library --target service`.
- Columns hold 720/720 whether the command is 194 or 303 characters, and `.cmd` scrolls internally.

49 tests pass, including new ones asserting both `when` predicates behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)